### PR TITLE
chore: remove webpack devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ report
 app/**/*.js
 app/**/*.map
 package-lock.json
+
+# Webpack files
+tsconfig.esm.json
+webpack.config.js
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "version": "next"
     },
     "tns-android": {
-      "version": "next"
+      "version": "4.2.0-2018-06-18-02"
     }
   },
   "dependencies": {
@@ -30,31 +30,18 @@
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular-devkit/core": "~0.5.5",
-    "@angular/compiler-cli": "~6.0.0",
-    "@ngtools/webpack": "~6.0.0",
+    "@angular/compiler-cli": "~6.1.0-beta.1",
     "babel-traverse": "6.24.1",
     "babel-types": "6.24.1",
     "babylon": "6.17.0",
-    "clean-webpack-plugin": "~0.1.19",
     "codelyzer": "^4.0.0",
-    "copy-webpack-plugin": "~4.5.1",
-    "css-loader": "~0.28.7",
-    "extract-text-webpack-plugin": "~3.0.2",
     "filewalker": "^0.1.3",
     "lazy": "1.0.11",
     "nativescript-dev-typescript": "next",
     "nativescript-dev-webpack": "next",
-    "nativescript-worker-loader": "~0.8.1",
-    "raw-loader": "~0.5.1",
-    "resolve-url-loader": "~2.3.0",
     "tslint": "^5.4.3",
     "typescript": "~2.7.2",
-    "uglifyjs-webpack-plugin": "~1.1.6",
-    "webpack": "~4.5.0",
-    "webpack-bundle-analyzer": "^2.9.1",
-    "webpack-sources": "~1.1.0",
-    "webpack-cli": "~2.0.14"
+    "@angular-devkit/build-angular": "~0.7.0-rc.0"
   },
   "scripts": {
     "tslint": "tslint --config tslint.json 'app/**/*.ts'",


### PR DESCRIPTION
The removed devDependencies are dependencies of nativescript-dev-webpack now and are not needed in the app's package.json anymore.